### PR TITLE
Fix aborted stream handling and clean up stuck chat states

### DIFF
--- a/hooks/use-chat.ts
+++ b/hooks/use-chat.ts
@@ -70,8 +70,8 @@ export function useChat(options?: UseChatOptions) {
   };
 
   const processing = async (input: string, index?: number) => {
+    const updater = createUpdater(index);
     try {
-      const updater = createUpdater(index);
       const chatWithAI = createChatWithAI(index);
 
       const [stream, abort] = chatWithAI(input);
@@ -144,6 +144,9 @@ export function useChat(options?: UseChatOptions) {
             break;
           case 'error':
             updater(msg => {
+              msg.isPending = false;
+              msg.isStreaming = false;
+              msg.isThinking = false;
               msg.isAborted = true;
             });
             onFinished?.({ isAbort: false, isError: true, messages });
@@ -159,6 +162,12 @@ export function useChat(options?: UseChatOptions) {
               };
             });
             if (part.finishReason === 'error') {
+              updater(msg => {
+                msg.isPending = false;
+                msg.isStreaming = false;
+                msg.isThinking = false;
+                msg.isAborted = true;
+              });
               const error = new Error('Network error', { cause: `Stream terminated by ${finishReason}` });
               handleError(error);
             }
@@ -169,15 +178,30 @@ export function useChat(options?: UseChatOptions) {
         }
       }
     } catch (error) {
+      // Network failure or thrown exception before/during streaming — ensure
+      // the assistant message never stays stuck in a pending/streaming state.
+      updater(msg => {
+        msg.isPending = false;
+        msg.isStreaming = false;
+        msg.isThinking = false;
+        msg.isAborted = true;
+      });
       handleError(error as Error);
+    } finally {
+      stopRef.current = null;
     }
   };
 
   const sendMessage = async (input: string) => {
     const createAt = +new Date();
+    let assistantIndex = -1;
     setSessions(sessions => {
+      const msgs = sessions.data[current].messages;
+      // Capture the index now so processing always targets this specific
+      // assistant message, even if another send runs concurrently.
+      assistantIndex = msgs.length + 1;
       sessions.data[current].messages = [
-        ...sessions.data[current].messages,
+        ...msgs,
         { role: 'user', content: input, createAt },
         {
           role: 'assistant',
@@ -190,7 +214,7 @@ export function useChat(options?: UseChatOptions) {
       ];
     });
 
-    await processing(input);
+    await processing(input, assistantIndex);
   };
 
   const regenerate = async (index: number) => {

--- a/hooks/use-chat.ts
+++ b/hooks/use-chat.ts
@@ -71,6 +71,13 @@ export function useChat(options?: UseChatOptions) {
 
   const processing = async (input: string, index?: number) => {
     const updater = createUpdater(index);
+    const markAborted = () =>
+      updater(msg => {
+        msg.isPending = false;
+        msg.isStreaming = false;
+        msg.isThinking = false;
+        msg.isAborted = true;
+      });
     try {
       const chatWithAI = createChatWithAI(index);
 
@@ -143,12 +150,7 @@ export function useChat(options?: UseChatOptions) {
 
             break;
           case 'error':
-            updater(msg => {
-              msg.isPending = false;
-              msg.isStreaming = false;
-              msg.isThinking = false;
-              msg.isAborted = true;
-            });
+            markAborted();
             onFinished?.({ isAbort: false, isError: true, messages });
             handleError(part.error as Error);
 
@@ -160,14 +162,14 @@ export function useChat(options?: UseChatOptions) {
                 time: +new Date() - startTime,
                 tokens: totalUsage.totalTokens || 0
               };
-            });
-            if (part.finishReason === 'error') {
-              updater(msg => {
+              if (finishReason === 'error') {
                 msg.isPending = false;
                 msg.isStreaming = false;
                 msg.isThinking = false;
                 msg.isAborted = true;
-              });
+              }
+            });
+            if (finishReason === 'error') {
               const error = new Error('Network error', { cause: `Stream terminated by ${finishReason}` });
               handleError(error);
             }
@@ -178,14 +180,7 @@ export function useChat(options?: UseChatOptions) {
         }
       }
     } catch (error) {
-      // Network failure or thrown exception before/during streaming — ensure
-      // the assistant message never stays stuck in a pending/streaming state.
-      updater(msg => {
-        msg.isPending = false;
-        msg.isStreaming = false;
-        msg.isThinking = false;
-        msg.isAborted = true;
-      });
+      markAborted();
       handleError(error as Error);
     } finally {
       stopRef.current = null;
@@ -194,12 +189,9 @@ export function useChat(options?: UseChatOptions) {
 
   const sendMessage = async (input: string) => {
     const createAt = +new Date();
-    let assistantIndex = -1;
+    const assistantIndex = messages.length + 1;
     setSessions(sessions => {
       const msgs = sessions.data[current].messages;
-      // Capture the index now so processing always targets this specific
-      // assistant message, even if another send runs concurrently.
-      assistantIndex = msgs.length + 1;
       sessions.data[current].messages = [
         ...msgs,
         { role: 'user', content: input, createAt },

--- a/hooks/use-sessions.ts
+++ b/hooks/use-sessions.ts
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { withImmer } from '@/lib/utils';
 import { sessions } from '@/store/sessions';
 
@@ -8,6 +10,22 @@ export function useSessions() {
   const [_sessions, _setSessions] = useStorageAtom(sessions);
   const [{ defaultModel }] = useSettings();
   const set = withImmer(_setSessions);
+
+  useEffect(() => {
+    set(sessions => {
+      for (const session of sessions.data) {
+        for (const msg of session.messages) {
+          if (msg.isPending || msg.isStreaming || msg.isThinking) {
+            msg.isPending = false;
+            msg.isStreaming = false;
+            msg.isThinking = false;
+            msg.isAborted = true;
+          }
+        }
+      }
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const create = () => {
     set(sessions => {


### PR DESCRIPTION
This change improves chat resilience by ensuring assistant messages correctly transition out of pending/streaming/thinking states on errors or aborts. Abort handling is centralized, the correct assistant message is now targeted during processing, and stale in‑progress flags are cleaned up when sessions rehydrate to prevent stuck UI after reloads.